### PR TITLE
Added Customizable Options For Debug & Release

### DIFF
--- a/buildzri.config.json
+++ b/buildzri.config.json
@@ -35,6 +35,16 @@
             "/EHsc",
             "/Os",
             "/link"
-        ]
+        ],
+        "debug": {
+            "linux": [
+                "-G"
+            ]
+        },
+        "release": {
+            "linux": [
+                "-O3"
+            ]
+        }
     }
 }

--- a/buildzri.config.json
+++ b/buildzri.config.json
@@ -35,16 +35,16 @@
             "/EHsc",
             "/Os",
             "/link"
-        ],
-        "debug": {
-            "linux": [
-                "-G"
-            ]
-        },
-        "release": {
-            "linux": [
-                "-O3"
-            ]
-        }
+        ]
+    },
+    "debugOptions": {
+        "linux": [
+            "-O0"
+        ]
+    },
+    "releaseOptions": {
+        "linux": [
+            "-O3"
+        ]
     }
 }

--- a/scripts/bz.py
+++ b/scripts/bz.py
@@ -236,8 +236,7 @@ def print_ascii_art():
 
 if __name__ == '__main__':
     with open(BZ_CONFIG_FILE) as configFile:
-        # print_ascii_art()
+        print_ascii_art()
         C = json.loads(configFile.read())
-        print(get_options())
-        # cmd = build_compiler_cmd()
-        # compile(cmd)
+        cmd = build_compiler_cmd()
+        compile(cmd)

--- a/scripts/bz.py
+++ b/scripts/bz.py
@@ -16,6 +16,8 @@ BZ_ISLINUX = BZ_OS == 'linux'
 BZ_ISDARWIN = BZ_OS == 'darwin'
 BZ_ISWIN = BZ_OS == 'windows'
 BZ_ISVERBOSE = '--verbose' in sys.argv
+BZ_ISDEBUG = '--debug' in sys.argv or '-d' in sys.argv
+BZ_ISRELEASE = not BZ_ISDEBUG and '--release' in sys.argv or '-r' in sys.argv
 
 def get_arch(short_names = True):
     arch = platform.machine().lower()
@@ -169,14 +171,27 @@ def get_options():
     if 'options' not in C:
         return ''
 
-    opt_defs = ['*', BZ_OS]
     opts = ''
 
+    if BZ_ISDEBUG and 'debug' in C['options']:
+        debug_opts = C['options']['debug']
+        if BZ_OS in debug_opts:
+            for entry in debug_opts[BZ_OS]:
+                opts += '%s ' % apply_template_vars(entry)
+
+    if BZ_ISRELEASE and 'release' in C['options']:
+        debug_opts = C['options']['release']
+        if BZ_OS in debug_opts:
+            for entry in debug_opts[BZ_OS]:
+                opts += '%s ' % apply_template_vars(entry)
+
+    opt_defs = ['*', BZ_OS]
     for opt_def in opt_defs:
         if opt_def not in C['options']:
             continue
         for entry in C['options'][opt_def]:
             opts += '%s ' % apply_template_vars(entry)
+    
     return opts
 
 def build_compiler_cmd():

--- a/scripts/bz.py
+++ b/scripts/bz.py
@@ -173,16 +173,15 @@ def get_options():
 
     opts = ''
 
-    if BZ_ISDEBUG and 'debug' in C['options']:
-        debug_opts = C['options']['debug']
+    if BZ_ISDEBUG and 'debugOptions' in C:
+        debug_opts = C['debugOptions']
         if BZ_OS in debug_opts:
             for entry in debug_opts[BZ_OS]:
                 opts += '%s ' % apply_template_vars(entry)
-
-    if BZ_ISRELEASE and 'release' in C['options']:
-        debug_opts = C['options']['release']
-        if BZ_OS in debug_opts:
-            for entry in debug_opts[BZ_OS]:
+    elif BZ_ISRELEASE and 'releaseOptions' in C:
+        release_opts = C['releaseOptions']
+        if BZ_OS in release_opts:
+            for entry in release_opts[BZ_OS]:
                 opts += '%s ' % apply_template_vars(entry)
 
     opt_defs = ['*', BZ_OS]
@@ -191,7 +190,7 @@ def get_options():
             continue
         for entry in C['options'][opt_def]:
             opts += '%s ' % apply_template_vars(entry)
-    
+
     return opts
 
 def build_compiler_cmd():
@@ -237,7 +236,8 @@ def print_ascii_art():
 
 if __name__ == '__main__':
     with open(BZ_CONFIG_FILE) as configFile:
-        print_ascii_art()
+        # print_ascii_art()
         C = json.loads(configFile.read())
-        cmd = build_compiler_cmd()
-        compile(cmd)
+        print(get_options())
+        # cmd = build_compiler_cmd()
+        # compile(cmd)


### PR DESCRIPTION
This PR Adds Ability To Customize The Options Depending On Release.
This Means You can turn up or turn down optimization levels And Much More depending On if it's release or debug mode and anything like that.

To Enable The Debug Mode Use The `-d` or `--debug` Flag, and For Release Mode Use The `-r` or `--release` flag.
Note if debug and release both are passed like `-d -r` then it will select debug by default instead of release, if no flag is passed nothing is checked, making the debug/release mode optional.